### PR TITLE
Fix navigation links and implement coupon modal scratch card

### DIFF
--- a/public/assets/js/main.js
+++ b/public/assets/js/main.js
@@ -23,6 +23,15 @@
   // Ensure product catalog exists even if products.js fails to load
   window.CATALOG = Array.isArray(window.CATALOG) ? window.CATALOG : [];
 
+  const NAV_LINKS = [
+    { label: 'Our Story', href: 'index.html#our-story' },
+    { label: 'Shop Tees', href: 'index.html#products' },
+    { label: 'Support', href: 'index.html#support' },
+    { label: 'Cart', href: 'cart.html' }
+  ];
+
+  const COUPON_CODE = 'ALUM15';
+
   /*
    * ===================================================================
    *  1. DOM & UTILITY HELPERS
@@ -34,6 +43,11 @@
   const $$ = (selector, root = document) => [...root.querySelectorAll(selector)];
   const escapeHtml = (str = "") =>
     str.replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c] || c));
+
+  const setAriaExpanded = (el, expanded) => {
+    if (!el) return;
+    el.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+  };
 
   /*
    * ===================================================================
@@ -296,6 +310,21 @@
     });
   };
 
+  const initNavigationLinks = () => {
+    const lists = $$('.nav-links');
+    if (!lists.length) return;
+    const currentPath = window.location.pathname.split('/').pop() || 'index.html';
+    const template = NAV_LINKS.map(({ href, label }) => {
+      const [base] = href.split('#');
+      const isActive = currentPath === base || (currentPath === '' && base === 'index.html');
+      const ariaCurrent = isActive ? ' aria-current="page"' : '';
+      return `<li><a class="nav-link${isActive ? ' active' : ''}" href="${href}"${ariaCurrent}>${escapeHtml(label)}</a></li>`;
+    }).join('');
+    lists.forEach((list) => {
+      list.innerHTML = template;
+    });
+  };
+
   // --- Mini-Cart Sidebar ---
   const initMiniCart = () => {
     const miniCart = $('#mini-cart');
@@ -309,13 +338,15 @@
       miniCart.setAttribute('aria-hidden', 'false');
       const panel = $('#mini-cart .mini-cart-panel') || $('#mini-cart .mini-cart__panel') || miniCart;
       cleanupFocusTrap = trapFocus(panel);
+      setAriaExpanded(toggleButton, true);
     };
 
     const closeCart = () => {
       miniCart.classList.remove('is-open');
       miniCart.setAttribute('aria-hidden', 'true');
       cleanupFocusTrap();
-      toggleButton.focus();
+      setAriaExpanded(toggleButton, false);
+      toggleButton?.focus();
     };
 
     toggleButton?.addEventListener('click', openCart);
@@ -343,8 +374,20 @@
 
     menuToggle.addEventListener('click', () => {
       const isOpen = mainNav.classList.toggle('is-open');
-      menuToggle.setAttribute('aria-expanded', isOpen);
+      menuToggle.classList.toggle('is-open', isOpen);
+      setAriaExpanded(menuToggle, isOpen);
     });
+
+    mainNav.addEventListener('click', (event) => {
+      if (!mainNav.classList.contains('is-open')) return;
+      if (event.target.closest('.nav-link')) {
+        mainNav.classList.remove('is-open');
+        menuToggle.classList.remove('is-open');
+        setAriaExpanded(menuToggle, false);
+      }
+    });
+
+    setAriaExpanded(menuToggle, false);
   };
 
   // --- Search ---
@@ -421,6 +464,204 @@
         }
     });
   };
+
+  const setupScratchCard = (canvas, onReveal) => {
+    if (!canvas || typeof canvas.getContext !== 'function') {
+      return { reveal: () => {} };
+    }
+    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+    const container = canvas.parentElement;
+    const bounds = container.getBoundingClientRect();
+    const width = Math.max(bounds.width, 280);
+    const height = Math.max(bounds.height, 160);
+    const dpr = window.devicePixelRatio || 1;
+    canvas.width = width * dpr;
+    canvas.height = height * dpr;
+    canvas.style.width = `${width}px`;
+    canvas.style.height = `${height}px`;
+    ctx.scale(dpr, dpr);
+    ctx.fillStyle = '#B99B71';
+    ctx.fillRect(0, 0, width, height);
+    ctx.fillStyle = '#D6C2A5';
+    ctx.fillRect(0, 0, width, height);
+    ctx.globalCompositeOperation = 'destination-out';
+    let scratching = false;
+    let revealed = false;
+
+    const scratch = (event) => {
+      const rect = canvas.getBoundingClientRect();
+      const x = event.clientX - rect.left;
+      const y = event.clientY - rect.top;
+      ctx.beginPath();
+      ctx.arc(x, y, 24, 0, Math.PI * 2);
+      ctx.fill();
+    };
+
+    const evaluateReveal = () => {
+      if (revealed) return;
+      const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+      let cleared = 0;
+      for (let i = 3; i < imageData.data.length; i += 4) {
+        if (imageData.data[i] === 0) cleared++;
+      }
+      const total = canvas.width * canvas.height;
+      if (total && cleared / total > 0.5) {
+        revealed = true;
+        onReveal();
+      }
+    };
+
+    const handlePointerDown = (event) => {
+      scratching = true;
+      canvas.setPointerCapture(event.pointerId);
+      scratch(event);
+      canvas.style.cursor = 'grabbing';
+    };
+
+    const handlePointerMove = (event) => {
+      if (!scratching) return;
+      scratch(event);
+    };
+
+    const handlePointerUp = (event) => {
+      if (!scratching) return;
+      scratching = false;
+      if (canvas.hasPointerCapture(event.pointerId)) {
+        canvas.releasePointerCapture(event.pointerId);
+      }
+      evaluateReveal();
+      canvas.style.cursor = '';
+    };
+
+    canvas.addEventListener('pointerdown', handlePointerDown);
+    canvas.addEventListener('pointermove', handlePointerMove);
+    canvas.addEventListener('pointerup', handlePointerUp);
+    canvas.addEventListener('pointerleave', handlePointerUp);
+
+    const clearCard = () => {
+      revealed = true;
+      ctx.globalCompositeOperation = 'destination-out';
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+    };
+
+    return {
+      reveal: clearCard
+    };
+  };
+
+  const initCouponModal = () => {
+    const toggle = $('#coupon-toggle');
+    if (!toggle) return;
+    let overlay = null;
+    let cleanupFocusTrap = () => {};
+    let scratchCard = null;
+    const handleScratchReveal = () => {
+      revealCoupon();
+      toast(`Coupon unlocked! Use code ${COUPON_CODE}.`);
+    };
+
+    const modalContainer = $('#modal-container') || (() => {
+      const div = document.createElement('div');
+      div.id = 'modal-container';
+      document.body.appendChild(div);
+      return div;
+    })();
+
+    const revealCoupon = () => {
+      if (!overlay) return;
+      const wrapper = overlay.querySelector('.scratch-card-container');
+      wrapper?.classList.add('is-revealed');
+      scratchCard?.reveal();
+      const canvas = overlay.querySelector('#scratch-canvas');
+      if (canvas) canvas.style.cursor = 'default';
+      State.couponRevealed = true;
+      setStored(STORAGE_KEYS.COUPON, true);
+      const message = overlay.querySelector('.coupon-message');
+      if (message) message.textContent = `Code ${COUPON_CODE} unlocked! Use it at checkout for bundle savings.`;
+      if (navigator.clipboard?.writeText) {
+        navigator.clipboard.writeText(COUPON_CODE).catch(() => {});
+      }
+    };
+
+    const closeModal = () => {
+      if (!overlay) return;
+      overlay.classList.remove('is-open');
+      overlay.setAttribute('aria-hidden', 'true');
+      cleanupFocusTrap();
+      setAriaExpanded(toggle, false);
+      toggle.focus();
+    };
+
+    const handleEscape = (event) => {
+      if (event.key === 'Escape' && overlay?.classList.contains('is-open')) {
+        event.preventDefault();
+        closeModal();
+      }
+    };
+
+    const ensureModal = () => {
+      if (overlay) return;
+      overlay = document.createElement('div');
+      overlay.className = 'modal-overlay';
+      overlay.id = 'coupon-modal';
+      overlay.setAttribute('role', 'dialog');
+      overlay.setAttribute('aria-modal', 'true');
+      overlay.setAttribute('aria-hidden', 'true');
+      overlay.innerHTML = `
+        <div class="modal-panel" role="document">
+          <button type="button" class="modal-close" data-close-modal aria-label="Close coupon modal">×</button>
+          <h2>Scratch &amp; save</h2>
+          <p>Reveal your alumni discount for vintage tees.</p>
+          <div class="scratch-card-container">
+            <canvas id="scratch-canvas" width="320" height="180"></canvas>
+            <div class="coupon-code" aria-live="polite" role="status">${COUPON_CODE}</div>
+          </div>
+          <p class="coupon-message" aria-live="polite"></p>
+          <p class="coupon-note">Use code <strong>${COUPON_CODE}</strong> when you add three tees to unlock 15% off.</p>
+        </div>
+      `;
+      modalContainer.appendChild(overlay);
+
+      const closeBtn = overlay.querySelector('[data-close-modal]');
+      closeBtn?.addEventListener('click', closeModal);
+      overlay.addEventListener('click', (event) => {
+        if (event.target === overlay) closeModal();
+      });
+      document.addEventListener('keydown', handleEscape);
+    };
+
+    const ensureScratchCard = () => {
+      if (!overlay || scratchCard) return;
+      const canvas = overlay.querySelector('#scratch-canvas');
+      if (!canvas) return;
+      scratchCard = setupScratchCard(canvas, handleScratchReveal);
+      if (State.couponRevealed) {
+        scratchCard.reveal();
+      }
+    };
+
+    const openModal = () => {
+      ensureModal();
+      if (!overlay) return;
+      overlay.classList.add('is-open');
+      overlay.setAttribute('aria-hidden', 'false');
+      setAriaExpanded(toggle, true);
+      const panel = overlay.querySelector('.modal-panel');
+      cleanupFocusTrap = trapFocus(panel) || (() => {});
+      if (State.couponRevealed) {
+        revealCoupon();
+      }
+      requestAnimationFrame(() => {
+        ensureScratchCard();
+        if (State.couponRevealed) {
+          revealCoupon();
+        }
+      });
+    };
+
+    toggle.addEventListener('click', openModal);
+    setAriaExpanded(toggle, false);
+  };
   
   /*
    * ===================================================================
@@ -432,11 +673,13 @@
     loadState(); // Load data from localStorage first
 
     // Global initializers
+    initNavigationLinks();
     initThemeToggle();
     initMiniCart();
     initMobileNav();
     initSearch();
     initContactForm();
+    initCouponModal();
     updateCartCount();
 
     // Page-specific initializers

--- a/public/assets/styles.css
+++ b/public/assets/styles.css
@@ -133,8 +133,20 @@ a:hover {
   color: var(--text);
 }
 
+.menu-toggle .icon-menu {
+  display: block;
+}
+
 .menu-toggle .icon-close {
   display: none;
+}
+
+.menu-toggle.is-open .icon-menu {
+  display: none;
+}
+
+.menu-toggle.is-open .icon-close {
+  display: block;
 }
 
 .main-nav {
@@ -776,6 +788,19 @@ textarea {
   cursor: grab;
 }
 
+.scratch-card-container canvas {
+  width: 100%;
+  height: 100%;
+}
+
+.scratch-card-container.is-revealed #scratch-canvas {
+  display: none;
+}
+
+.scratch-card-container.is-revealed .coupon-code {
+  box-shadow: inset 0 0 0 2px var(--brand);
+}
+
 .coupon-code {
   position: absolute;
   inset: 0;
@@ -788,6 +813,20 @@ textarea {
   background: var(--bg);
   border: 2px dashed var(--border);
   border-radius: 12px;
+}
+
+.coupon-message {
+  text-align: center;
+  font-weight: 600;
+  color: var(--brand);
+  min-height: 1.5rem;
+  margin-top: 1rem;
+}
+
+.coupon-note {
+  text-align: center;
+  color: var(--muted);
+  margin-top: 0.75rem;
 }
 
 /* Accessibility */

--- a/public/cart.html
+++ b/public/cart.html
@@ -93,6 +93,8 @@
     </div>
   </aside>
 
+  <div id="modal-container"></div>
+
   <script src="assets/js/products.js"></script>
   <script src="assets/js/main.js"></script>
   <script src="assets/js/cart.js"></script>

--- a/public/privacy.html
+++ b/public/privacy.html
@@ -93,6 +93,8 @@
     </div>
   </aside>
 
+  <div id="modal-container"></div>
+
   <script src="assets/js/products.js"></script>
   <script src="assets/js/main.js"></script>
 </body>

--- a/public/product.html
+++ b/public/product.html
@@ -89,6 +89,8 @@
     </div>
   </aside>
 
+  <div id="modal-container"></div>
+
   <script src="assets/js/products.js"></script>
   <script src="assets/js/main.js"></script>
   <script src="assets/js/product.js"></script>

--- a/public/terms.html
+++ b/public/terms.html
@@ -86,6 +86,8 @@
     </div>
   </aside>
 
+  <div id="modal-container"></div>
+
   <script src="assets/js/products.js"></script>
   <script src="assets/js/main.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- populate the header navigation dynamically and sync the hamburger toggle state
- implement a reusable coupon scratch-card modal with persistent unlock state and accessibility polish
- add modal containers and styling tweaks so the coupon feature and menu behave across all pages

## Testing
- Not run (static changes)

------
https://chatgpt.com/codex/tasks/task_e_69006aa7a7148330a943a89a84cc83d1